### PR TITLE
Change the logfile path to ${stash.home}/log

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,14 +7,14 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
-        <file>${stash.home}/logs/scs-plugin.log</file>
+        <file>${stash.home}/log/scs-plugin.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="scs-plugin-debug" class="ch.qos.logback.core.FileAppender">
-        <file>${stash.home}/logs/scs-plugin-debug.log</file>
+        <file>${stash.home}/log/scs-plugin-debug.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
From Stash's documentation, the logs are placed under a _log_ directory
and not in _logs_

https://confluence.atlassian.com/stash/stash-debug-logging-282988756.html